### PR TITLE
Switch to unversioned collection `nodePackages` for npm dependencies in

### DIFF
--- a/data/default.nix
+++ b/data/default.nix
@@ -18,7 +18,7 @@ let
       inherit name src;
 
       buildInputs = [ elmPackages.elm ]
-        ++ lib.optional outputJavaScript nodePackages_10_x.uglify-js;
+        ++ lib.optional outputJavaScript nodePackages.uglify-js;
 
       buildPhase = pkgs.elmPackages.fetchElmDeps {
         elmPackages = import srcs;


### PR DESCRIPTION
Switch to unversioned collection `nodePackages` for npm dependencies in default.nix

Versioned collections were removed in <https://github.com/NixOS/nixpkgs/commit/ca3f5fe13004619cccec33ce4337f8dee29260d4>

Addresses <https://github.com/cachix/elm2nix/issues/37>