### PR TITLE
Fix compatibility with newer versions of uglify.js

### DIFF
--- a/data/default.nix
+++ b/data/default.nix
@@ -37,7 +37,7 @@ let
           \${lib.optionalString outputJavaScript ''
             echo "minifying \${elmfile module}"
             uglifyjs $out/\${module}.\${extension} --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters,keep_fargs=false,unsafe_comps,unsafe' \\
-                | uglifyjs --mangle --output=$out/\${module}.min.\${extension}
+                | uglifyjs --mangle --output $out/\${module}.min.\${extension}
           ''}
         '') targets)}
       '';


### PR DESCRIPTION
Compatibility with newer versions of uglify.js

Fixes error:

```
minifying ./client/Main.elm
ERROR: invalid option --output=/nix/store/4asmp8ppn1y1n628i6fnain1yzv62x42-planning-game-client-0.3.0/Main.min.js
events.js:292
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
```