### PR TITLE
Prevent duplicates between src and test dependencies

### DIFF
--- a/src/Elm2Nix.hs
+++ b/src/Elm2Nix.hs
@@ -87,7 +87,7 @@ convert = runCLI $ do
   testDeps <- either throwErr return (parseElmJsonDeps "test-dependencies" elmJson)
   liftIO (hPutStrLn stderr "Prefetching tarballs and computing sha256 hashes ...")
 
-  sources <- liftIO (mapConcurrently (uncurry prefetch) (deps ++ testDeps))
+  sources <- liftIO (mapConcurrently (uncurry prefetch) (nub $ deps ++ testDeps))
   liftIO (putStrLn (generateNixSources sources))
 
 initialize :: IO ()

--- a/src/Elm2Nix.hs
+++ b/src/Elm2Nix.hs
@@ -13,7 +13,7 @@ import Control.Monad (liftM2)
 import Control.Monad.Except (liftIO, MonadIO)
 import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
 import Data.Aeson (Value(..))
-import Data.List (intercalate)
+import Data.List (intercalate, nub)
 import Data.HashMap.Strict (HashMap)
 import Data.String.Here
 import Data.Text (Text)


### PR DESCRIPTION
In some local projects it happens from time to time that the same definition is created in `elm-srcs.nix`.

This is largely due to errors in the required dependencies themselves, but this should not result in the expressions failing due to both the src and test definitions that contain the same package in error.