### PR TITLE
revise help output

### DIFF
--- a/elm2nix/Main.hs
+++ b/elm2nix/Main.hs
@@ -47,6 +47,7 @@ getOpts = customExecParser p (infoH opts rest)
 
       $ elm2nix init > default.nix
       $ elm2nix convert > elm-srcs.nix
+      $ elm2nix snapshot
       $ nix-build
 
       Note: You have to run elm2nix from top-level directory of an Elm project.
@@ -56,5 +57,5 @@ getOpts = customExecParser p (infoH opts rest)
     opts = subparser
       ( command "init" (infoH (pure Init) (progDesc "Generate default.nix (printed to stdout)"))
      <> command "convert" (infoH (pure Convert) (progDesc "Generate Nix expressions for elm.json using nix-prefetch-url"))
-     <> command "snapshot" (infoH (pure Snapshot) (progDesc "Generate versions.dat"))
+     <> command "snapshot" (infoH (pure Snapshot) (progDesc "Generate registry.dat"))
       )


### PR DESCRIPTION
quick revision of the output from elm2nix --help. gave it a quick test on a project and seems normal.

output now looks like this:

```
bburdette@BB-5520:~/op-code/elm2nix$ cd result/bin/
bburdette@BB-5520:~/op-code/elm2nix/result/bin$ ./elm2nix
elm2nix 0.2.1

Usage: elm2nix COMMAND
  Convert Elm project to Nix expressions

Available options:
  -h,--help                Show this help text

Available commands:
  init                     Generate default.nix (printed to stdout)
  convert                  Generate Nix expressions for elm.json using
                           nix-prefetch-url
  snapshot                 Generate registry.dat



    Usage:

      $ elm2nix init > default.nix
      $ elm2nix convert > elm-srcs.nix
      $ elm2nix snapshot
      $ nix-build

      Note: You have to run elm2nix from top-level directory of an Elm project.

bburdette@BB-5520:~/op-code/elm2nix/result/bin$
```