### PR TITLE
Aeson >= 2 compat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,5 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v15
     - run: ./scripts/tests.sh


### PR DESCRIPTION
These changes allow for the building of elm2nix when using aeson >= 2.0

I'm not sure what the official build tool for the project is, but it would be good to know in order to get the automated builds working once more. Not sure if that would be considered out of scope for this change. 