### PR TITLE
Update repo location in cabal file

### DIFF
--- a/elm2nix.cabal
+++ b/elm2nix.cabal
@@ -5,9 +5,9 @@
 name:           elm2nix
 version: 0.3.1
 synopsis:       Turn your Elm project into buildable Nix project
-description:    Please see the README on Github at <https://github.com/domenkozar/elm2nix#readme>
-homepage:       https://github.com/domenkozar/elm2nix#readme
-bug-reports:    https://github.com/domenkozar/elm2nix/issues
+description:    Please see the README on Github at <https://github.com/cachix/elm2nix#readme>
+homepage:       https://github.com/cachix/elm2nix#readme
+bug-reports:    https://github.com/cachix/elm2nix/issues
 author:         Domen Kozar
 maintainer:     domen@dev.si
 copyright:      2017-2022 Domen Kozar
@@ -23,7 +23,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/domenkozar/elm2nix
+  location: https://github.com/cachix/elm2nix
 
 library
   hs-source-dirs:


### PR DESCRIPTION
This ensures the Hackage page sends people to the right place. Obviously not a huge deal, just noticed it when I was looking at the new release :)

(In the meantime, maybe you could do a quick push to the old repo to bring it up to date?)